### PR TITLE
Support for CoffeeScript source files in combination with coffeeify

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var through = require('through');
 var falafel = require('falafel');
 
 module.exports = function (file) {
-  if (!/\.js$/.test(file)) return through();
+  if (!/\.(js|coffee)$/.test(file)) return through();
   var data = '';
 
   var tr = through(write, end);


### PR DESCRIPTION
When a .coffee source file is run through transforms [coffeeify, debowerify], debowerify can operate upon it just as it would upon a .js source file with no problems. This is stopped by the guard clause at the start of the module, however, which only lets .js files through. This commit widens the regexp to also accept .coffee extensions.

Completely removing that guard clause might be reasonable; as far as I know, browserify only ever looks at  source files of some kind or another, and if users have dropped in the appropriate transforms (coffeeify, liveify, and so on) there's no reason not to run debowerify on those non-.js files as well. I've made only the minimal change needed to get my CoffeeScript-based project working right, though---dropping the line entirely is worth consideration nonetheless.
