### PR TITLE
When a component's "main" is an array, use the first item in the array

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ module.exports = function (file) {
         if (moduleName && moduleName in bowerModules) {
           var module = bowerModules[moduleName];
           if (module && module.source && module.source.main) {
-            var fullModulePath = path.resolve(module.source.main);
+            var mainModule = Array.isArray(module.source.main) ? module.source.main[0] : module.source.main;
+            var fullModulePath = path.resolve(mainModule);
             var relativeModulePath = './' + path.relative(path.dirname(file), fullModulePath);
             node.arguments[0].update(JSON.stringify(relativeModulePath));
           }


### PR DESCRIPTION
`bower.json` defines the `main` option as (validly) being either a string or an array. debowerify previously assumed that `main` was always a string, so valid Bower components that chose to use an array instead would produce a `TypeError`. This patch has debowerify test the content of `main`, and if it's an array it will instead use the first element of the array.
