### PR TITLE
Corrects spelling of 'peerDependencies' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "through": "~2.3.4",
     "falafel": "~0.2.1"
   },
-  "peerDepencies": {
+  "peerDependencies": {
     "bower": "~0.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm` doesn't recognise "peerDepencies". This corrects that issue.
