### PR TITLE
When there is no main field, assume module's entry point is called moduleName.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,14 @@ module.exports = function (file) {
       bower.commands.ls({map: true})
         .on('data', function (map) {
           bowerModules = map;
-          next();
+          bower.commands.ls({paths: true})
+            .on('data', function(paths) {
+              for (m in paths) {
+                if(!paths.hasOwnProperty(m)) continue;
+                bowerModules[m].path = paths[m];
+              }
+              next();
+            });
         });
     } else {
       next();
@@ -57,7 +64,7 @@ module.exports = function (file) {
             } else {
               // if 'main' wasn't specified by this component, let's try
               // guessing that the main file is moduleName.js
-              mainModule = path.join("components", moduleName, moduleName+".js");
+              mainModule = path.join(module.path, moduleName+".js");
             }
             var fullModulePath = path.resolve(mainModule);
             var relativeModulePath = './' + path.relative(path.dirname(file), fullModulePath);


### PR DESCRIPTION
It turns out there are lots of Bower components that don't specify their `main` file! In addition, there are plenty of Bower components that don't actually have a `bower.json` or `component.json` at all, and the one Bower automatically generates also lacks a `main` field.

Previously debowerify couldn't cope with those particular components at all. I noted, however, that many components simply have a main file named after the module itself; having debowerify "guess" that the module's entry point is at `moduleName.js`, when not told otherwise by a `main` field, will allow for many more components to be debowerified without manual `bower.json` modification.

If a module's entry point _isn't_ at `moduleName.js`, an error is now produced along the lines of "module not found: ../components/moduleName/moduleName.js", which I think is as clear as the error that used to be produced for this case (a simple "module not found: moduleName"), with the added advantage of hinting (somewhat) toward the fact that the missing `main` field is the source of the error.
