### PR TITLE
Improves error message emitted when there's a problem in debowerify

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,11 @@ module.exports = function (file) {
       next();
     }
 
-    var self = this;
-
     function next() {
       var output;
       try { output = parse(); }
       catch (err) {
-        self.emit('error', new Error(
+        tr.emit('error', new Error(
           err.toString().replace('Error: ', '') + ' (' + file + ')')
         );
       }


### PR DESCRIPTION
For some reason, the `self` reference was previously often undefined in case of errors while browserifying, which meant the error shown to the user was along the lines of "`undefined` has no method `self`" instead of the actual cause of problems. Simply referencing `tr` directly (which is what every other reference to the stream in the file does anyway) seems to correct this.
