### PR TITLE
Now works with bower 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "falafel": "~0.2.1"
   },
   "peerDependencies": {
-    "bower": "~0.9.2"
+    "bower": "~1.0.3"
   },
   "devDependencies": {
     "domready": "~0.2.11",


### PR DESCRIPTION
Api in bower changed, events emitted were different. Also simplified as there is now only a single bower call required.

Fixes #7
