### PR TITLE
Offline builds crash with an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (file) {
   function write (buf) { data += buf; }
   function end () {
     if (bowerModules === undefined) {
-      bower.commands.list({map: true})
+      bower.commands.list({offline: true})
         .on('end', function (map) {
           bowerModules = map;
           next();


### PR DESCRIPTION
Best I could do with research brought me to conclude that the bower list command never supported the `map` option. The side effect was that the bower code was attempting to check for new versions of the packages the first time debowerify tried to scan for dependencies. This caused the promise to be rejected when your on a plane and have no internet access, causing the `error` event to trigger, in turn causeing debowerify to bail out and end the build. This means you could not build your apps while on a plane or where you don't have online access.

Bower allows an offline option to prevent this. I changed the unused `map` option to the now used `offline` option and the return value from bower is the same.
