### PR TITLE
Allow requiring submodules within a module

### DIFF
--- a/public/by_subpath.js
+++ b/public/by_subpath.js
@@ -1,0 +1,2 @@
+var Base62 = require('base62/lib/base62');
+console.log(Base62.decode(Base62.encode(12345)));

--- a/test/index.js
+++ b/test/index.js
@@ -43,4 +43,22 @@ describe('debowerify', function() {
     });
   });
 
+  it('should be able to debowerify a submodule', function(done) {
+    var jsPath = path.join(__dirname, '..', 'public', 'by_subpath.js');
+    var b = browserify();
+    b.add(jsPath);
+    b.transform(debowerify);
+    b.bundle(function (err, src) {
+      if (err) return done(err);
+      vm.runInNewContext(src, {
+        console: {
+          log: function (msg) {
+            expect(msg).to.equal(12345);
+            done();
+          }
+        }
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
For example

``` js
var component = require('flight/lib/component');
```

This is important for larger AMD projects that contain multiple .js files.
