### PR TITLE
fix reference error with AMD-style require statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,8 @@ module.exports = function (file) {
     var output = falafel(data, function (node) {
       if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'require') {
         var pth = node.arguments[0].value;
+        if(!pth) return;
+
         var moduleName = getModuleName(pth);
         var moduleSubPath = getModuleSubPath(pth);
 


### PR DESCRIPTION
I was seeing similar issues to #18 because some of the files being processed had require statements that did not have a string argument.
