### PR TITLE
Checking file extension in main

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ module.exports = function (file) {
 
         if (!requiredFilePath){
           if (pkgMeta && pkgMeta.main) {
-            requiredFilePath = Array.isArray(pkgMeta.main) ? pkgMeta.main[0] : pkgMeta.main;
+            requiredFilePath = Array.isArray(pkgMeta.main) ? pkgMeta.main.filter(function (file) { return /\.js$/.test(file); })[0] : pkgMeta.main;
           } else {
             // if 'main' wasn't specified by this component, let's try
             // guessing that the main file is moduleName.js


### PR DESCRIPTION
At the moment the first file in the `bower.json.main` list will be processed, regardless of file extension

I've added a filter by `/\.js$/` to make sure the file that gets processed is js (and not css, mustache etc.)

As a suggestion, have you considered checking the alias list in `package.json.browser` for the correct file name to fetch too?
