### PR TITLE
Support literate Coffeescript files (.litcoffee/.coffee.md)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var through = require('through');
 var falafel = require('falafel');
 
 module.exports = function (file) {
-  if (!/\.(js|jsx|coffee|ls)$/.test(file)) return through();
+  if (!/\.(js|jsx|(lit)?coffee(\.md)?|ls)$/.test(file)) return through();
   var data = '';
 
   var tr = through(write, end);


### PR DESCRIPTION
Currently, debowerify only supports the .coffee extension, but literate coffeescript files don't work, even though coffeeify supports them.  This pull request changes the filename filter to support such files.
