### PR TITLE
Returning an error message if bower reports a dependency as missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,9 @@ module.exports = function (file) {
         if (!module) return;
 
         if (module.missing) {
-	        throw new Error('could not resolve dependency ' + moduleName + 
-			      ' : bower returns the module as known but not found (did you forget to run bower install ?)');
-	      }
+          throw new Error('could not resolve dependency ' + moduleName + 
+            ' : bower returns the module as known but not found (did you forget to run bower install ?)');
+	}
 	      
         var pkgMeta = module.pkgMeta;
         var requiredFilePath = moduleSubPath;


### PR DESCRIPTION
When debowerify is ran before a bower install, it returns an obscure error related to path.join (because bower has found the project in the json file but it was not installed). In this case bower returns module.missing as true, so I have added an exception to help the user into understanding why the process fail.
