### PR TITLE
numeric filename support

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ module.exports = function (file) {
     var output = falafel(data, function (node) {
       if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'require') {
         var pth = node.arguments[0].value;
+        if(typeof pth === 'number') pth += '';
         if(!pth) return;
 
         var moduleName = getModuleName(pth);
@@ -105,7 +106,6 @@ module.exports = function (file) {
     });
 
     function getModuleName(path){
-      if(typeof path === 'number') return path + ''
       return path.split('/')[0]
     }
 


### PR DESCRIPTION
Numeric filenames currently return a TypeObject XXX has no method 'split' error. This eases integration of minified bower main scripts and enables numeric filenames.
