### PR TITLE
Updated packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   "license": "BSD",
   "dependencies": {
     "bower": "~1.3.12",
-    "esprima": "^1.2.2",
-    "ordered-ast-traverse": "^0.1.1",
+    "esprima": "^2.0.0",
+    "ordered-ast-traverse": "^1.1.1",
     "through": "~2.3.4"
   },
   "devDependencies": {
     "domready": "~1.0.4",
     "deamdify": "~0.1.1",
     "chai": "~1.9.0",
-    "mocha": "~1.17.1",
-    "browserify": "~3.32.0"
+    "mocha": "^2.1.0",
+    "browserify": "~9.0.0"
   },
   "readmeFilename": "README.md",
   "directories": {


### PR DESCRIPTION
Hey, not sure if you're okay with this. I think running tests on browserify ~v9.0.0 makes more sense since that is the most likely version people would be using in the near future.