### PR TITLE
Introduce overrides for `main`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,11 +2,24 @@
   "name": "debowerify-test",
   "verision": "0.0.0",
   "dependencies": {
-    "js-base64": "~2.1.2"
+    "js-base64": "~2.1.2",
+    "test-package-d": "./test/fixtures/test-package-d",
+    "test-package-e": "./test/fixtures/test-package-e"
   },
   "devDependencies": {
     "base62": "~0.4.0",
     "test-package-a": "./test/fixtures/test-package-a",
     "test-package-c": "./test/fixtures/test-package-c"
+  },
+  "overrides": {
+    "test-package-d": {
+      "main": "main.js"
+    },
+    "test-package-e": {
+      "main": {
+        "production": "main.min.js",
+        "development": "main.js"
+      }
+    }
   }
 }

--- a/bower_components/test-package-d/.bower.json
+++ b/bower_components/test-package-d/.bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-package-d",
+  "main": [
+    "./unknownfile.js"
+  ],
+  "_source": "/Users/lincoln/Work/Checkouts/debowerify/test/fixtures/test-package-d",
+  "_target": "*",
+  "_originalSource": "./test/fixtures/test-package-d"
+}

--- a/bower_components/test-package-d/bower.json
+++ b/bower_components/test-package-d/bower.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-package-d",
+  "main": [
+    "./unknownfile.js"
+  ]
+}

--- a/bower_components/test-package-d/main.js
+++ b/bower_components/test-package-d/main.js
@@ -1,0 +1,1 @@
+loaded = true;

--- a/bower_components/test-package-e/.bower.json
+++ b/bower_components/test-package-e/.bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-package-e",
+  "main": [
+    "./main.js",
+    "./main.min.js"
+  ],
+  "_source": "/Users/lincoln/Work/Checkouts/debowerify/test/fixtures/test-package-e",
+  "_target": "*",
+  "_originalSource": "./test/fixtures/test-package-e"
+}

--- a/bower_components/test-package-e/bower.json
+++ b/bower_components/test-package-e/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package-e",
+  "main": [
+    "./main.js",
+    "./main.min.js"
+  ]
+}

--- a/bower_components/test-package-e/main.js
+++ b/bower_components/test-package-e/main.js
@@ -1,0 +1,1 @@
+notMinified = true;

--- a/bower_components/test-package-e/main.min.js
+++ b/bower_components/test-package-e/main.min.js
@@ -1,0 +1,1 @@
+minified = true;

--- a/index.js
+++ b/index.js
@@ -112,8 +112,10 @@ module.exports = function (file, options) {
       var requiredFilePaths = moduleSubPath;
 
       if (!requiredFilePaths){
-        if (pkgMeta && pkgMeta.main) {
-          requiredFilePaths = Array.isArray(pkgMeta.main) ? pkgMeta.main.filter(function (file) { return /\.js$/.test(file); }) : [ pkgMeta.main ];
+        var pkg = (bowerModules.pkgMeta.overrides[moduleName] || {}).main || pkgMeta.main;
+        if (pkgMeta && pkg) {
+          pkg = pkg[process.env.NODE_ENV] || pkg;
+          requiredFilePaths = Array.isArray(pkg) ? pkg.filter(function (file) { return /\.js$/.test(file); }) : [ pkg ];
         } else {
           // if 'main' wasn't specified by this component, let's try
           // guessing that the main file is moduleName.js

--- a/public/overrides.js
+++ b/public/overrides.js
@@ -1,0 +1,1 @@
+require('test-package-d')

--- a/public/overrides2.js
+++ b/public/overrides2.js
@@ -1,0 +1,1 @@
+require('test-package-e')

--- a/test/fixtures/test-package-d/bower.json
+++ b/test/fixtures/test-package-d/bower.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-package-d",
+  "main": [
+    "./unknownfile.js"
+  ]
+}

--- a/test/fixtures/test-package-d/main.js
+++ b/test/fixtures/test-package-d/main.js
@@ -1,0 +1,1 @@
+loaded = true;

--- a/test/fixtures/test-package-e/bower.json
+++ b/test/fixtures/test-package-e/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-package-e",
+  "main": [
+    "./main.js",
+    "./main.min.js"
+  ]
+}

--- a/test/fixtures/test-package-e/main.js
+++ b/test/fixtures/test-package-e/main.js
@@ -1,0 +1,1 @@
+notMinified = true;

--- a/test/fixtures/test-package-e/main.min.js
+++ b/test/fixtures/test-package-e/main.min.js
@@ -1,0 +1,1 @@
+minified = true;

--- a/test/index.js
+++ b/test/index.js
@@ -72,7 +72,7 @@ describe('debowerify', function() {
     });
   });
 
-  it.only('should be able to debowerify a module with multiple main entries', function(done) {
+  it('should be able to debowerify a module with multiple main entries', function(done) {
     var b = browserify();
     b.add(path.join(__dirname, '..', 'public', 'multiple_main_entries.js'));
     b.transform(debowerify);
@@ -85,4 +85,31 @@ describe('debowerify', function() {
     });
   });
 
+  it('should be able to debowerify a module with a broken `main` section with overrides', function(done) {
+    var b = browserify();
+    b.add(path.join(__dirname, '..', 'public', 'overrides.js'));
+    b.transform(debowerify);
+    b.bundle(function (err, src) {
+      if (err) return done(err);
+      var sandbox = { loaded: false };
+      vm.runInNewContext(src, sandbox);
+      expect(sandbox.loaded).to.equal(true);
+      done();
+    });
+  });
+
+  it('should be able to use NODE_ENV to choose which file to debowerify', function(done) {
+    process.env.NODE_ENV = 'production'
+    var b = browserify();
+    b.add(path.join(__dirname, '..', 'public', 'overrides2.js'));
+    b.transform(debowerify);
+    b.bundle(function (err, src) {
+      if (err) return done(err);
+      var sandbox = { minified: null, notMinified: null };
+      vm.runInNewContext(src, sandbox);
+      expect(sandbox.minified).to.equal(true);
+      expect(sandbox.notMinified).to.equal(null);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Debowerify doesn't really help if the bower package doesn't declare the
right files in the `main` section of their bower.json file. This patch
introduces the `overrides` section that allows the user declaring
dependencies to override the main section of the bower.json file of the
package they depend on.

This strategy was copied from `main-bower-files`:

  https://github.com/ck86/main-bower-files#options