### PR TITLE
Bumped bower version to ~1.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Eugene Ware <eugene@noblesamurai.com>",
   "license": "BSD",
   "dependencies": {
-    "bower": "~1.3.12",
+    "bower": "~1.7.9",
     "esprima": "^2.0.0",
     "ordered-ast-traverse": "^1.1.1",
     "through": "~2.3.4"


### PR DESCRIPTION
Prevents graceful-fs warnings during npm install that were due to old bower dependencies.
